### PR TITLE
feat: allow to skip invalid assert conditions

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -136,6 +136,7 @@ type RunnerConfig struct {
 	AssertInvalid bool `config:"assert_invalid"`
 
 	ContinueOnAssertInvalid bool `config:"continue_on_assert_invalid"`
+	SkipInvalidAssert       bool `config:"skip_invalid_assert"`
 
 	// Exit(2) if any error occurred
 	AssertError bool `config:"assert_error"`

--- a/main.go
+++ b/main.go
@@ -148,7 +148,8 @@ func startLoader(cfg *LoaderConfig) *LoadStats {
 			loadGen.Stop()
 		case stats := <-statsAggregator:
 			aggStats.NumErrs += stats.NumErrs
-			aggStats.NumInvalid += stats.NumInvalid
+			aggStats.NumAssertInvalid += stats.NumAssertInvalid
+			aggStats.NumAssertSkipped += stats.NumAssertSkipped
 			aggStats.NumRequests += stats.NumRequests
 			aggStats.TotReqSize += stats.TotReqSize
 			aggStats.TotRespSize += stats.TotRespSize
@@ -217,7 +218,8 @@ func startLoader(cfg *LoaderConfig) *LoadStats {
 	}
 
 	if cfg.RunnerConfig.AssertInvalid {
-		fmt.Printf("Assert Invalid:\t%v\n", aggStats.NumInvalid)
+		fmt.Printf("Assert Invalid:\t\t%v\n", aggStats.NumAssertInvalid)
+		fmt.Printf("Assert Skipped:\t\t%v\n", aggStats.NumAssertSkipped)
 	}
 
 	for k, v := range aggStats.StatusCode {
@@ -440,7 +442,7 @@ func runLoaderConfig(config *LoaderConfig) int {
 
 	aggStats := startLoader(config)
 	if aggStats != nil {
-		if config.RunnerConfig.AssertInvalid && aggStats.NumInvalid > 0 {
+		if config.RunnerConfig.AssertInvalid && aggStats.NumAssertInvalid > 0 {
 			return 1
 		}
 		if config.RunnerConfig.AssertError && aggStats.NumErrs > 0 {

--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ func startLoader(cfg *LoaderConfig) *LoadStats {
 	}
 
 	if cfg.RunnerConfig.AssertInvalid {
-		fmt.Printf("Number of Invalid:\t%v\n", aggStats.NumInvalid)
+		fmt.Printf("Assert Invalid:\t%v\n", aggStats.NumInvalid)
 	}
 
 	for k, v := range aggStats.StatusCode {


### PR DESCRIPTION

This pull request includes several changes to improve error handling and reporting in the load testing framework. The most important changes include adding a new configuration option to skip invalid assertions, updating the statistics structure to differentiate between different types of assertion errors, and adding validation for requests during the warmup phase.

Closes https://github.com/infinilabs/loadgen/issues/5

Improvements to error handling:

* [`domain.go`](diffhunk://#diff-913e8e323a1edf7d41530cd18ba29216c42fbaad0f36599bccca4cbd9bd53f2aR139): Added `SkipInvalidAssert` field to `RunnerConfig` struct to allow skipping invalid assertions.

Updates to statistics reporting:

* [`loader.go`](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL69-R70): Changed `NumInvalid` to `NumAssertInvalid` and added `NumAssertSkipped` in `LoadStats` struct to better categorize assertion errors.
* [`loader.go`](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL166-R167): Updated error counting logic in `doRequest` function to increment `NumAssertSkipped` if `SkipInvalidAssert` is enabled and `NumAssertInvalid` otherwise. [[1]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eL166-R167) [[2]](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eR226-R241)

Request validation:

* [`loader.go`](diffhunk://#diff-322de476adda6446d58b08a7166a7b8fd50b3c060b2f088b44e122c065e3a18eR484-R489): Added request validation in `Warmup` function to log and panic on invalid requests.

Updates to main loader logic:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L151-R152): Updated `startLoader` and `runLoaderConfig` functions to handle new statistics fields and print detailed assertion error counts. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L151-R152) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L220-R222) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L443-R445)