### PR TITLE
chore: use fasttemplate ref with infini.sh

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	log "github.com/cihub/seelog"
-	"github.com/valyala/fasttemplate"
+	"infini.sh/framework/lib/fasttemplate"
 
 	"infini.sh/framework/core/conditions"
 	"infini.sh/framework/core/errors"

--- a/domain_test.go
+++ b/domain_test.go
@@ -25,7 +25,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/valyala/fasttemplate"
+	"infini.sh/framework/lib/fasttemplate"
 	"io"
 	"log"
 	"math/rand"


### PR DESCRIPTION
## What does this PR do
This pull request updates the import paths for the `fasttemplate` library to use a new location within the `infini.sh` framework. The changes ensure consistency and alignment with the updated library structure.

### Updates to import paths:

* [`domain.go`](diffhunk://#diff-913e8e323a1edf7d41530cd18ba29216c42fbaad0f36599bccca4cbd9bd53f2aL41-R41): Changed the `fasttemplate` import path from `github.com/valyala/fasttemplate` to `infini.sh/framework/lib/fasttemplate`.
* [`domain_test.go`](diffhunk://#diff-3edd4097a3d00729b33f8a8b5a32f858adbd3d20e29833a73950b584cd0144a2L28-R28): Updated the `fasttemplate` import path to match the new location within `infini.sh/framework/lib/fasttemplate`.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation