### PR TITLE
ci: support scoped conventional commits in commit-message-check

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -13,10 +13,11 @@ jobs:
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '^(change:|feat:|improve:|perf:|dep:|docs:|test:|ci:|style:|refactor:|fix:|fixdoc:|fixup:|merge|Merge|bumpver:|chore:|build:) .+$'
+          pattern: '^(change|feat|improve|perf|dep|docs|test|ci|style|refactor|fix|fixdoc|fixup|bumpver|chore|build)(\([^)]+\))?: .+$|^(merge|Merge|update|Update) .+$'
           flags: 'gm'
           error: |
-            Subject line has to contain a commit type, e.g.: "chore: blabla" or a merge commit e.g.: "merge xxx".
+            Subject line has to contain a commit type, e.g.: "chore: blabla", "feat(scope): blabla" or a merge commit e.g.: "merge xxx".
+            An optional scope in parentheses is allowed after the type, e.g.: "feat(cookie): add cookie support".
             Valid types are:
               change        - API breaking change
               feat          - API compatible new feature


### PR DESCRIPTION
Sync `commit-message-check.yml` from framework to support scoped conventional commits (e.g. `feat(scope): ...`).