### PR TITLE
feat: support ipv6

### DIFF
--- a/docs/content.en/docs/getting-started/reference.md
+++ b/docs/content.en/docs/getting-started/reference.md
@@ -61,6 +61,29 @@ env:
 
 **Usage:** `$[[env.ES_ENDPOINT]]`
 
+**IPv6 Support:**
+
+Loadgen fully supports IPv6 addresses. Use standard bracket notation (`[ipv6addr]:port`) in URLs:
+
+```yaml
+env:
+  ES_ENDPOINT: "http://[::1]:9200"
+  # Or with a real IPv6 address:
+  # ES_ENDPOINT: "http://[fd00::1]:9200"
+  # Link-local address with zone ID (URL-encoded %25 for %):
+  # ES_ENDPOINT: "http://[fe80::18df:9883:1e27:b040%25en0]:9200"
+```
+
+Or from the command line:
+
+```bash
+ES_ENDPOINT="http://[::1]:9200" loadgen -run loadgen.dsl -d 5 -c 2
+# Link-local with zone ID:
+ES_ENDPOINT="http://[fe81::18df:9883:1e27:b040%25en0]:9200" loadgen -run loadgen.dsl -d 5 -c 2
+```
+
+> **Note:** For link-local IPv6 addresses with a zone ID (e.g. `fe80::1%en0`), the `%` must be URL-encoded as `%25` in the URL.
+
 ---
 
 ## Runner Configuration (runner)

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -10,6 +10,8 @@ Information about release notes of INFINI Loadgen is provided here.
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- feat: support ipv6 based endpoints
+
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 - Add native Go modules support for Loadgen, including local module wiring to the sibling Framework checkout and PR checks that follow the Go version declared in `go.mod`.

--- a/docs/content.zh/docs/getting-started/reference.md
+++ b/docs/content.zh/docs/getting-started/reference.md
@@ -61,6 +61,29 @@ env:
 
 **引用方式：** `$[[env.ES_ENDPOINT]]`
 
+**IPv6 支持：**
+
+Loadgen 完整支持 IPv6 地址。使用标准方括号格式（`[ipv6地址]:端口`）即可：
+
+```yaml
+env:
+  ES_ENDPOINT: "http://[::1]:9200"
+  # 或使用实际 IPv6 地址：
+  # ES_ENDPOINT: "http://[fd00::1]:9200"
+  # 链路本地地址带 zone ID（URL 中 % 需编码为 %25）：
+  # ES_ENDPOINT: "http://[fe80::18df:9883:1e27:b040%25en0]:9200"
+```
+
+或通过命令行传入：
+
+```bash
+ES_ENDPOINT="http://[::1]:9200" loadgen -run loadgen.dsl -d 5 -c 2
+# 链路本地地址带 zone ID：
+ES_ENDPOINT="http://[fe81::18df:9883:1e27:b040%25en0]:9200" loadgen -run loadgen.dsl -d 5 -c 2
+```
+
+> **注意：** 对于带 zone ID 的链路本地 IPv6 地址（如 `fe80::1%en0`），URL 中的 `%` 必须编码为 `%25`。
+
 ---
 
 ## 运行控制（runner）

--- a/docs/content.zh/docs/release-notes/_index.md
+++ b/docs/content.zh/docs/release-notes/_index.md
@@ -10,6 +10,8 @@ title: "版本历史"
 ## Latest (In development)  
 ### ❌ Breaking changes  
 ### 🚀 Features  
+- feat: 压测地址支持 IPv6
+
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 - 为 Loadgen 增加原生 Go Modules 支持，包括与同级 Framework 本地仓库的模块联动，以及按 `go.mod` 声明版本执行的 PR 检查。

--- a/loader.go
+++ b/loader.go
@@ -108,7 +108,7 @@ func NewLoadGenerator(duration int, goroutines int, statsAggregator chan *LoadSt
 	}
 	if dialTimeout > 0 {
 		httpClient.Dial = func(addr string) (net.Conn, error) {
-			return fasthttp.DialTimeout(addr, time.Duration(dialTimeout)*time.Second)
+			return fasthttp.DialDualStackTimeout(addr, time.Duration(dialTimeout)*time.Second)
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do

```
➜  loadgen git:(main) ✗ ES_ENDPOINT="https://[::1]:9203" ES_USERNAME=admin  ES_PASSWORD="Z+J&PA4yrD2*-RlJta&0Cdw%" ./bin/loadgen -config loadgen.yml
[06-10 11:37:33] [INF] [env.go:216] configuration auto reload enabled
[06-10 11:37:33] [INF] [env.go:222] watching config: /Users/medcl/go/src/infini.sh/loadgen/config
[WARNING] THIS IS IN DEVELOPMENT MODE.
   __   ___  _      ___  ___   __    __
  / /  /___\/_\    /   \/ _ \ /__\/\ \ \
 / /  //  ///_\\  / /\ / /_\//_\ /  \/ /
/ /__/ \_//  _  \/ /_// /_\\//__/ /\  /
\____|___/\_/ \_/___,'\____/\__/\_\ \/

HOME: https://github.com/infinilabs/loadgen/

[LOADGEN] A http load generator and testing suite, open-sourced under the GNU AGPLv3.
[LOADGEN] 1.0.0_SNAPSHOT#001, 2026-06-10 03:36:08, 2027-12-31 10:10:10, bdbdb7bd8d4b, ebe59126e0a2, N/A
[06-10 11:37:33] [INF] [env.go:216] configuration auto reload enabled
[06-10 11:37:33] [INF] [env.go:222] watching config: /Users/medcl/go/src/infini.sh/loadgen/config
[06-10 11:37:33] [INF] [app.go:314] initializing loadgen, pid: 17740
[06-10 11:37:33] [INF] [app.go:315] using data: data/loadgen/nodes/ctdug3bq50k7meba8jqg
[06-10 11:37:33] [INF] [app.go:316] using config: /Users/medcl/go/src/infini.sh/loadgen/loadgen.yml
[06-10 11:37:33] [INF] [module.go:183] started plugin: statsd
[06-10 11:37:33] [INF] [module.go:189] all modules are started
[06-10 11:37:33] [INF] [instance.go:100] workspace: /Users/medcl/go/src/infini.sh/loadgen/data/loadgen/nodes/ctdug3bq50k7meba8jqg
[06-10 11:37:33] [INF] [app.go:559] loadgen is up and running now.

24 requests finished in 3.379574877s, 44.61MB sent, 46.37MB received

[Loadgen Client Metrics]
Requests/sec:		4.77
Request Traffic/sec:	8.86MB
Total Transfer/sec:	18.06MB
Fastest Request:	1ms
Slowest Request:	591.459542ms
Status 200:		24

[Latency Metrics]
24 samples of 24 events
Cumulative:	3.379574877s
HMean:		111.580201ms
Avg.:		140.815619ms
p50: 		104.114708ms
p75:		144.712042ms
p95:		277.158ms
p99:		591.459542ms
p999:		591.459542ms
Long 5%:	591.459542ms
Short 5%:	79.744917ms
Max:		591.459542ms
Min:		79.744917ms
Range:		511.714625ms
StdDev:		106.138075ms
Rate/sec.:	4.77

[Latency Distribution]
  79.744ms - 130.916ms ------------------------------
 130.916ms - 182.087ms --------
 182.087ms - 233.259ms -
  233.259ms - 284.43ms -
  284.43ms - 335.602ms -


[Estimated Server Metrics]
Requests/sec:		7.10
Avg Req Time:		140.815619ms
Transfer/sec:		26.92MB

```

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation